### PR TITLE
Implement configurable scenario-based wargame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # ai-wargame
-Tool for automating war-gaming like scenario exploration, using LLMs as actors and game master.
+
+Tool for automating scenario-based war-gaming using LLMs as actors and
+as the game master. Models are accessed through [OpenRouter](https://openrouter.ai/)
+so any supported LLM can be plugged in.
+
+## Running a Scenario
+
+1. Create a scenario folder under `scenarios/` with a `config.yaml`
+   describing the initial world state, metrics to track, each actor and
+the game master. See `scenarios/example/config.yaml` for a template.
+2. Export your `OPENROUTER_API_KEY`.
+3. Run the scenario for a number of rounds:
+
+```bash
+python run.py scenarios/example --rounds 1
+```
+
+After each round a Markdown log is written under `scenarios/<name>/logs`
+containing the initial world state for that round, actions by each actor
+and the updated world state as decided by the game master.
+
+## Requirements
+
+- Python 3.10+
+- `openai` Python client (for OpenRouter API)
+- `pyyaml`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+pyyaml

--- a/run.py
+++ b/run.py
@@ -1,0 +1,24 @@
+"""Command line entry point for the wargame simulation."""
+
+from __future__ import annotations
+
+import argparse
+
+from wargame.scenario import load_scenario
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a wargame scenario")
+    parser.add_argument("scenario", help="Path to scenario folder")
+    parser.add_argument(
+        "--rounds", type=int, default=1, help="Number of rounds to simulate"
+    )
+    args = parser.parse_args()
+
+    game = load_scenario(args.scenario)
+    for _ in range(args.rounds):
+        game.run_round()
+
+
+if __name__ == "__main__":
+    main()

--- a/scenarios/example/config.yaml
+++ b/scenarios/example/config.yaml
@@ -1,0 +1,22 @@
+world:
+  description: |
+    The world is at a fragile peace. Two nations, Alpha and Beta, have tense relations.
+  metrics:
+    stability: 50
+    resources: 100
+actors:
+  Alpha:
+    llm:
+      model: openai/gpt-3.5-turbo
+      system_prompt: |
+        You represent nation Alpha. Consider your strategic goals carefully.
+  Beta:
+    llm:
+      model: openai/gpt-3.5-turbo
+      system_prompt: |
+        You represent nation Beta. Act in your nation's interest.
+game_master:
+  llm:
+    model: openai/gpt-4-turbo
+    system_prompt: |
+      You are the impartial game master. Update the world state based on actor actions.

--- a/wargame/__init__.py
+++ b/wargame/__init__.py
@@ -1,0 +1,9 @@
+"""Core package for running AI-assisted wargame simulations."""
+
+from .actors import Actor
+from .game import Game
+from .game_master import GameMaster
+from .llm import LLM
+from .scenario import load_scenario
+
+__all__ = ["Actor", "Game", "GameMaster", "LLM", "load_scenario"]

--- a/wargame/actors.py
+++ b/wargame/actors.py
@@ -1,0 +1,40 @@
+"""Actor definitions for the wargame simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .llm import LLM
+
+
+@dataclass
+class Actor:
+    """Represents a single actor in the simulation."""
+
+    name: str
+    llm: LLM
+    notes: List[str] = field(default_factory=list)
+
+    def act(self, world_state: str, log: str) -> str:
+        """Generate the actor's action for the round.
+
+        Parameters
+        ----------
+        world_state:
+            The textual description of the current world state.
+        log:
+            Concatenated log from previous rounds.
+        """
+
+        history = "\n".join(self.notes)
+        prompt = (
+            "You are taking part in a scenario-based exercise."\
+            "\n\nPrevious private notes:\n" + history +
+            "\n\nWorld state:\n" + world_state +
+            "\n\nGame log so far:\n" + log +
+            "\n\nDescribe your next action in character."
+        )
+        action = self.llm.complete(prompt)
+        self.notes.append(action)
+        return action

--- a/wargame/game.py
+++ b/wargame/game.py
@@ -1,0 +1,63 @@
+"""Game loop orchestration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .actors import Actor
+from .game_master import GameMaster
+
+
+@dataclass
+class Game:
+    """Core game class managing rounds and logging."""
+
+    world_state: str
+    actors: Dict[str, Actor]
+    game_master: GameMaster
+    scenario_path: str
+    log: List[Dict[str, str]] = field(default_factory=list)
+    round_no: int = 0
+
+    def __post_init__(self) -> None:
+        self.log_dir = os.path.join(self.scenario_path, "logs")
+        os.makedirs(self.log_dir, exist_ok=True)
+
+    def run_round(self) -> None:
+        """Execute a single round of the game."""
+        self.round_no += 1
+        round_initial = self.world_state
+        log_text = "\n".join(
+            f"Round {i+1}: {entry['new_state']}" for i, entry in enumerate(self.log)
+        )
+
+        actions = {}
+        for name, actor in self.actors.items():
+            actions[name] = actor.act(self.world_state, log_text)
+
+        new_state = self.game_master.decide(self.world_state, actions)
+
+        round_record = {
+            "initial": round_initial,
+            "actions": actions,
+            "new_state": new_state,
+        }
+        self.log.append(round_record)
+        self.world_state = new_state
+
+        self._write_round_md(round_record)
+
+    # logging
+    def _write_round_md(self, record: Dict[str, str]) -> None:
+        path = os.path.join(self.log_dir, f"round_{self.round_no}.md")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(f"# Round {self.round_no}\n\n")
+            f.write("## Initial World State\n")
+            f.write(record["initial"] + "\n\n")
+            f.write("## Actions\n")
+            for name, action in record["actions"].items():
+                f.write(f"### {name}\n{action}\n\n")
+            f.write("## New World State\n")
+            f.write(record["new_state"] + "\n")

--- a/wargame/game_master.py
+++ b/wargame/game_master.py
@@ -1,0 +1,26 @@
+"""Game master logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .llm import LLM
+
+
+@dataclass
+class GameMaster:
+    """The game master updates the world state based on actor actions."""
+
+    llm: LLM
+
+    def decide(self, world_state: str, actions: Dict[str, str]) -> str:
+        """Produce an updated world state."""
+        actions_text = "\n".join(f"{name}: {act}" for name, act in actions.items())
+        prompt = (
+            "You are the game master in a scenario-based exercise."\
+            "\n\nCurrent world state:\n" + world_state +
+            "\n\nActors actions:\n" + actions_text +
+            "\n\nUpdate the world state in light of these actions and describe the result."
+        )
+        return self.llm.complete(prompt)

--- a/wargame/llm.py
+++ b/wargame/llm.py
@@ -1,0 +1,56 @@
+"""LLM connector using OpenRouter.
+
+This module provides a thin wrapper around the OpenAI-compatible API
+exposed by OpenRouter. Different models can be selected simply by
+specifying the model name from OpenRouter.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from openai import OpenAI
+
+
+BASE_URL = "https://openrouter.ai/api/v1"
+
+
+@dataclass
+class LLM:
+    """Simple OpenRouter-backed language model.
+
+    Parameters
+    ----------
+    model:
+        The model name available through OpenRouter.
+    system_prompt:
+        Initial system prompt for the model.
+    api_key:
+        Optional API key; if not given the ``OPENROUTER_API_KEY``
+        environment variable will be used.
+    """
+
+    model: str
+    system_prompt: str = ""
+    api_key: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        key = self.api_key or os.getenv("OPENROUTER_API_KEY")
+        if not key:
+            raise RuntimeError(
+                "OpenRouter API key missing. Set OPENROUTER_API_KEY environment variable."
+            )
+        self._client = OpenAI(api_key=key, base_url=BASE_URL)
+
+    def complete(self, prompt: str) -> str:
+        """Generate a completion from the model."""
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return response.choices[0].message.content.strip()

--- a/wargame/scenario.py
+++ b/wargame/scenario.py
@@ -1,0 +1,50 @@
+"""Scenario loading utilities."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import yaml
+
+from .actors import Actor
+from .game import Game
+from .game_master import GameMaster
+from .llm import LLM
+
+
+def load_scenario(path: str) -> Game:
+    """Load a scenario from ``path`` and return a :class:`Game` object."""
+    config_path = os.path.join(path, "config.yaml")
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    world = config["world"]["description"]
+    metrics = config["world"].get("metrics", {})
+    if metrics:
+        metrics_text = "\n".join(f"{k}: {v}" for k, v in metrics.items())
+        world = world + "\n" + metrics_text
+
+    actors_cfg: Dict[str, dict] = config.get("actors", {})
+    actors: Dict[str, Actor] = {}
+    for name, cfg in actors_cfg.items():
+        llm_cfg = cfg["llm"]
+        actors[name] = Actor(
+            name=name,
+            llm=LLM(
+                model=llm_cfg["model"],
+                system_prompt=llm_cfg.get("system_prompt", ""),
+                api_key=llm_cfg.get("api_key"),
+            ),
+        )
+
+    gm_cfg = config["game_master"]["llm"]
+    gm = GameMaster(
+        LLM(
+            model=gm_cfg["model"],
+            system_prompt=gm_cfg.get("system_prompt", ""),
+            api_key=gm_cfg.get("api_key"),
+        )
+    )
+
+    return Game(world_state=world, actors=actors, game_master=gm, scenario_path=path)


### PR DESCRIPTION
## Summary
- add OpenRouter-backed LLM connector and actor/game-master classes
- support scenario folders with YAML configs and markdown round logs
- include example scenario and CLI entry point

## Testing
- `python -m py_compile run.py wargame/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c87f3c778832d9fab42c87b835871